### PR TITLE
Add plugin web-bundle (.zip) content type for subscription streaming

### DIFF
--- a/src/ecommerce/helpers.py
+++ b/src/ecommerce/helpers.py
@@ -1,6 +1,10 @@
+# These values are the wire contract for the `type` field returned by the plugin_subscriptions
+# endpoint. They must stay aligned with IW4MAdmin's PluginType enum ordinals
+# (Application/Plugin/PluginImporter.cs): Binary=0, Script=1, CSharpScript=2, Bundle=3.
 CONTENT_TYPE_UNKNOWN = -1
 CONTENT_TYPE_BINARY = 0
 CONTENT_TYPE_SCRIPT = 1
+CONTENT_TYPE_BUNDLE = 3
 
 
 def determine_content_type(content_name: str) -> int:
@@ -8,4 +12,8 @@ def determine_content_type(content_name: str) -> int:
         return CONTENT_TYPE_BINARY
     if content_name.lower().endswith('.js'):
         return CONTENT_TYPE_SCRIPT
+    # plugin web-bundle: a zip of manifest.json + lib/ (dll) + wwwroot/ + optional gsc/.
+    # encrypted and streamed verbatim like any other content; IW4MAdmin loads it in-memory.
+    if content_name.lower().endswith('.zip'):
+        return CONTENT_TYPE_BUNDLE
     return CONTENT_TYPE_UNKNOWN


### PR DESCRIPTION
Map *.zip subscription content to type 3, aligned with IW4MAdmin's PluginType.Bundle ordinal. Plugin web-bundles (manifest + lib/ + wwwroot/ + optional gsc/) are encrypted and streamed verbatim through the existing content pipeline; IW4MAdmin loads them in-memory. Only the type mapping in determine_content_type was content-aware, so this is the sole change.