### PR TITLE
fix: prefer game server IP for resolved external address

### DIFF
--- a/src/master/resources/instance.py
+++ b/src/master/resources/instance.py
@@ -45,9 +45,46 @@ class Instance(Resource):
             request.remote_addr
         )
 
+    @staticmethod
+    def _is_public_ipv4(ip_str) -> bool:
+        """True if the value is a literal, publicly routable IPv4 address."""
+        if not ip_str:
+            return False
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            return False
+        return ip.version == 4 and not (
+            ip.is_private or ip.is_loopback or ip.is_link_local or
+            ip.is_unspecified or ip.is_reserved or ip.is_multicast
+        )
+
+    @staticmethod
+    def _resolve_webfront_ipv4(webfront_url) -> str:
+        """Resolve the webfront hostname to a public IPv4 address (None if unavailable)."""
+        if not webfront_url:
+            return None
+        try:
+            from urllib.parse import urlparse
+            import socket
+            hostname = urlparse(webfront_url).hostname
+            if not hostname:
+                return None
+            # getaddrinfo with AF_INET forces IPv4
+            addrs = socket.getaddrinfo(hostname, None, socket.AF_INET)
+            if addrs:
+                webfront_ip = addrs[0][4][0]
+                if Instance._is_public_ipv4(webfront_ip):
+                    return webfront_ip
+        except Exception:
+            pass  # Ignore resolution errors
+        return None
+
     def _process_servers(self, data: dict, remote_ip: str) -> None:
         """Process and normalize server data."""
         servers = data.get('servers', [])
+        webfront_ip = False  # False = not looked up yet (resolution is deferred/cached)
+
         for server in servers:
             # Handle IP address
             parsed_ip = None
@@ -57,59 +94,51 @@ class Instance(Resource):
             except ValueError:
                 pass
 
+            # The address the instance reported for the game server itself
+            server_is_public = self._is_public_ipv4(server.get('ip'))
+
             # Update IP if missing, private, or loopback
             if 'ip' not in server or (parsed_ip and (
                 parsed_ip.is_private or parsed_ip.is_loopback or server['ip'] == '0.0.0.0'
             )):
                 server['ip'] = remote_ip
 
-            # Handle resolved_external_ip_address
+            # Handle resolved_external_ip_address - this is the address clients
+            # connect to, so the game server's own public address always wins.
+            # The instance/webfront host address is only a fallback for servers
+            # bound to internal or loopback addresses.
             # Priority:
-            # 1. Existing valid IPv4 resolved address
-            # 2. Remote IP (if IPv4)
-            # 3. Webfront URL hostname (if resolves to IPv4)
-            # 4. Remote IP (IPv6 fallback)
-            
-            resolved_ip = server.get('resolved_external_ip_address')
+            # 1. Server IP from the payload (if a public IPv4)
+            # 2. Instance-supplied resolved address (if a public IPv4)
+            # 3. Remote IP (if a public IPv4)
+            # 4. Webfront URL hostname (if it resolves to a public IPv4)
+            # 5. Remote IP (IPv6 / unknown fallback)
+
             candidate_ip = None
 
-            # Helper to validate public IPv4
-            def is_valid_public_ipv4(ip_str):
-                try:
-                    ip = ipaddress.ip_address(ip_str)
-                    return ip.version == 4 and not (ip.is_private or ip.is_loopback or ip_str == '0.0.0.0')
-                except ValueError:
-                    return False
+            # 1. Public game server address reported by the instance
+            if server_is_public:
+                candidate_ip = server['ip']
 
-            # 1. Check existing resolved IP
-            if resolved_ip and is_valid_public_ipv4(resolved_ip):
+            # 2. Resolved address supplied by the instance
+            resolved_ip = server.get('resolved_external_ip_address')
+            if not candidate_ip and self._is_public_ipv4(resolved_ip):
                 candidate_ip = resolved_ip
 
-            # 2. Check remote IP if we don't have a candidate yet
-            if not candidate_ip and is_valid_public_ipv4(remote_ip):
+            # 3. Address the heartbeat came from
+            if not candidate_ip and self._is_public_ipv4(remote_ip):
                 candidate_ip = remote_ip
 
-            # 3. Check webfront URL if we still don't have a candidate
-            if not candidate_ip and 'webfront_url' in data:
-                try:
-                    from urllib.parse import urlparse
-                    import socket
-                    hostname = urlparse(data['webfront_url']).hostname
-                    if hostname:
-                        # Try to resolve hostname to IPv4
-                        # getaddrinfo with AF_INET forces IPv4
-                        addrs = socket.getaddrinfo(hostname, None, socket.AF_INET)
-                        if addrs:
-                            webfront_ip = addrs[0][4][0]
-                            if is_valid_public_ipv4(webfront_ip):
-                                candidate_ip = webfront_ip
-                except Exception:
-                    pass  # Ignore resolution errors
+            # 4. Webfront hostname (resolved at most once per request)
+            if not candidate_ip:
+                if webfront_ip is False:
+                    webfront_ip = self._resolve_webfront_ipv4(data.get('webfront_url'))
+                candidate_ip = webfront_ip
 
-            # 4. Fallback to whatever remote_ip is (even if IPv6) if we found nothing
+            # 5. Fallback to whatever remote_ip is (even if IPv6) if we found nothing
             if not candidate_ip:
                 candidate_ip = remote_ip
-            
+
             server['resolved_external_ip_address'] = candidate_ip
 
             # Default version if not provided


### PR DESCRIPTION
## Problem

`resolved_external_ip_address` is being stored as the webfront host's IP even when the instance reports a public IP for the game server. For instances behind Cloudflare (or any proxy), that leaks the origin address through the API and the server list, and gives clients the wrong connect address.

The priority list in `_process_servers` never looked at the server address from the payload:

1. instance-supplied `resolved_external_ip_address` — but IW4MAdmin sends its *own* external IP here, i.e. the webfront host
2. `remote_ip` — the heartbeat source, i.e. the webfront/CF egress address
3. webfront URL hostname
4. `remote_ip`

So step 1 or 2 always won, regardless of how the game servers were configured.

## Fix

New priority, per server:

1. `server.ip` from the payload, if it is a public IPv4 — **the actual fix**
2. instance-supplied `resolved_external_ip_address`, if a public IPv4
3. `remote_ip`, if a public IPv4
4. webfront URL hostname resolved to a public IPv4
5. `remote_ip` fallback

The webfront/instance host address is now only used when the server binds an internal, loopback or unspecified address, which is what it was meant for.

Also included:

- Public IPv4 check tightened — link-local, unspecified, reserved and multicast are rejected too, not just private/loopback/`0.0.0.0`.
- The blocking `socket.getaddrinfo` webfront lookup ran once per server per heartbeat inside the loop. It now runs at most once per request, and only when nothing earlier in the chain produced a candidate.

## Notes

Existing bad rows self-correct on the next heartbeat via `batch_upsert_servers`; no migration needed.

Verified against the cases below (public server IP wins over an instance-supplied host IP; private/loopback/`0.0.0.0`/missing IP fall back to the host address; a hostname in `ip` keeps the instance-supplied resolved address; a private resolved address is ignored; DNS resolved once for N servers).
